### PR TITLE
Remove marked.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.8",
-    "@types/marked": "^2.0.2",
     "@types/nedb": "^1.8.11",
     "@types/node": "^14.11.8",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
@@ -36,7 +35,6 @@
     "discord.js": "^12.5.3",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "marked": "^2.0.3",
     "nedb": "^1.8.0"
   },
   "nodemonConfig": {

--- a/src/controllers/RythmController.ts
+++ b/src/controllers/RythmController.ts
@@ -2,7 +2,6 @@ import {Message, MessageEmbed} from "discord.js";
 import Log from "../util/Log";
 import {NeDBAdapter} from "../adapters/database/NeDBAdapter";
 import {PruneOption, Song, Source} from "../Types";
-import marked from "marked";
 import SettingsController from "./SettingsController";
 import {getGuild} from "../util/Util";
 
@@ -112,10 +111,9 @@ const parseSong = (message: Message): Song => {
 // "[Name of the Song](https://www.youtube.com/watch?v=link)"
 const parseNameAndLink = (markdown: string): {name: string, link: string} => {
     Log.debug(`Parsing name and link from: "${markdown}"`);
-    const tokens = marked.lexer(markdown);
-    const paragraph: any = tokens[0];
-    const link = paragraph.tokens[0].href;
-    const name = paragraph.tokens[0].text;
+    const separator = "](";
+    const link = markdown.slice(markdown.lastIndexOf(separator) + separator.length, -1);
+    const name = markdown.slice(1, markdown.lastIndexOf(separator));
     Log.debug(`found ${name} at ${link}`);
     return {name, link};
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,11 +124,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
-"@types/marked@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-2.0.2.tgz#33a15106383f6e42cd6bdd38093e6b19904e29e1"
-  integrity sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw==
-
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -1486,11 +1481,6 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
-marked@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.3.tgz#3551c4958c4da36897bda2a16812ef1399c8d6b0"
-  integrity sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
So I think our previous approach was a little unnecessarily heavyweight.
I was thinking about it and although we know those characters _could_ appear in _a_ URL, I don't know why we didn't think so see if those characters _would_ appear in a URL.

Most of the sources use alphanumeric hashes, so only Bandcamp has the risk. As far as I can tell, Bandcamp [disallows those](https://store.sigurros.com/album/--2) [characters in](https://u-ol.bandcamp.com/) [their product page URLs](https://coreysnelgrove.bandcamp.com/)