### PR TITLE
Prune warning on replacement

### DIFF
--- a/src/commands/impl/prune.ts
+++ b/src/commands/impl/prune.ts
@@ -14,7 +14,7 @@ const prune: CommandBinder = (client: Client) => ({
         if (!isPruneOption(arg)) {
             // Tell the user the proper usage
             return message.channel.send(`Prune must be set to '${PruneOption.ON}', '${PruneOption.OFF}', or '${PruneOption.REPLACE}'`);
-        } else if (arg === PruneOption.ON) {
+        } else if (arg === PruneOption.ON || arg === PruneOption.REPLACE) {
             Log.info("Attempting to enable message pruning");
             const clientMember = message.guild?.member(client.user);
             const manageMessages = clientMember?.hasPermission("MANAGE_MESSAGES");


### PR DESCRIPTION
Manage messages must be available for both ON and REPLACE, not just ON