### PR TITLE
Command arguments in user feedback should use monospace

### DIFF
--- a/src/commands/impl/mute.ts
+++ b/src/commands/impl/mute.ts
@@ -25,7 +25,7 @@ const mute: CommandBinder = () => ({
             return message.channel.send(`Mute is now \`${arg}\`${channelMessage}`);
         } else {
             // Tell the user the proper usage
-            return message.channel.send(`Mute must be set to '${MuteOption.ON}', '${MuteOption.OFF}', or '${MuteOption.WARN}'`);
+            return message.channel.send(`Mute must be set to \`${MuteOption.ON}\`, \`${MuteOption.OFF}\`, or \`${MuteOption.WARN}\``);
         }
     },
 });

--- a/src/commands/impl/prune.ts
+++ b/src/commands/impl/prune.ts
@@ -13,7 +13,7 @@ const prune: CommandBinder = (client: Client) => ({
         const [arg] = args;
         if (!isPruneOption(arg)) {
             // Tell the user the proper usage
-            return message.channel.send(`Prune must be set to '${PruneOption.ON}', '${PruneOption.OFF}', or '${PruneOption.REPLACE}'`);
+            return message.channel.send(`Prune must be set to \`${PruneOption.ON}\`, \`${PruneOption.OFF}\`, or \`${PruneOption.REPLACE}\``);
         } else if (arg === PruneOption.ON || arg === PruneOption.REPLACE) {
             Log.info("Attempting to enable message pruning");
             const clientMember = message.guild?.member(client.user);


### PR DESCRIPTION
I noticed that sometimes command arguments were in single quotation marks
> Mute must be set to 'on', 'off', or 'warn'

But thought it would be best to use monospace
> Mute must be set to `on`, `off`, or `warn`